### PR TITLE
CHAM-55 STT/TTS API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ application.yml
 # 환경 변수 파일
 .env
 .env.*
+src/main/resources/gcp/gcp-key.json
 
 ### log file ###
 logs

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 	implementation 'com.google.cloud:google-cloud-speech:4.32.0'
 	implementation 'com.google.protobuf:protobuf-java:3.25.1'
 	implementation 'com.google.cloud:google-cloud-storage:2.38.0'
-
+	implementation 'com.google.cloud:google-cloud-texttospeech:2.30.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+	implementation 'com.google.cloud:google-cloud-speech:4.32.0'
+	implementation 'com.google.protobuf:protobuf-java:3.25.1'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 	implementation 'com.google.cloud:google-cloud-speech:4.32.0'
 	implementation 'com.google.protobuf:protobuf-java:3.25.1'
+	implementation 'com.google.cloud:google-cloud-storage:2.38.0'
 
 }
 

--- a/src/main/java/com/example/demo/voice/controller/VoiceController.java
+++ b/src/main/java/com/example/demo/voice/controller/VoiceController.java
@@ -1,0 +1,4 @@
+package com.example.demo.voice.controller;
+
+public class VoiceController {
+}

--- a/src/main/java/com/example/demo/voice/controller/VoiceController.java
+++ b/src/main/java/com/example/demo/voice/controller/VoiceController.java
@@ -42,6 +42,14 @@ public class VoiceController {
         return ResponseEntity.ok(response);
     }
 
+    // TTS 스트리밍
+    @GetMapping(value = "/tts", produces = "audio/mpeg")
+    public ResponseEntity<byte[]> tts(@RequestParam String text) {
+        byte[] mp3Data = voiceService.synthesizeSpeech(text);
+        return ResponseEntity.ok()
+                .contentType(MediaType.valueOf("audio/mpeg"))
+                .body(mp3Data);
+    }
 
     // TTS 로그 저장
     @PostMapping("/tts-log")

--- a/src/main/java/com/example/demo/voice/controller/VoiceController.java
+++ b/src/main/java/com/example/demo/voice/controller/VoiceController.java
@@ -1,4 +1,39 @@
 package com.example.demo.voice.controller;
 
+import com.example.demo.voice.dto.TranscribedTextResponse;
+import com.example.demo.voice.dto.TtsLogRequest;
+import com.example.demo.voice.dto.TtsLogResponse;
+import com.example.demo.voice.service.VoiceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chat/voice")
 public class VoiceController {
+
+    private final VoiceService voiceService;
+
+    // 음성 파일 업로드 및 STT 처리
+    @PostMapping("/upload")
+    public ResponseEntity<TranscribedTextResponse> uploadAudio(
+            @RequestParam("audio_file") MultipartFile audioFile,
+            @RequestParam("session_id") Long sessionId
+//            @RequestHeader("Authorization") String authHeader
+    ) throws IOException {
+//        String token = authHeader.replace("Bearer ", "");
+        TranscribedTextResponse response = voiceService.handleAudioUpload(audioFile, sessionId, null);
+        return ResponseEntity.ok(response);
+    }
+
+
+    // TTS 로그 저장
+    @PostMapping("/tts-log")
+    public ResponseEntity<TtsLogResponse> saveTtsLog(@RequestBody TtsLogRequest request) {
+        return ResponseEntity.ok(voiceService.saveTtsLog(request));
+    }
 }

--- a/src/main/java/com/example/demo/voice/controller/VoiceController.java
+++ b/src/main/java/com/example/demo/voice/controller/VoiceController.java
@@ -4,7 +4,13 @@ import com.example.demo.voice.dto.TranscribedTextResponse;
 import com.example.demo.voice.dto.TtsLogRequest;
 import com.example.demo.voice.dto.TtsLogResponse;
 import com.example.demo.voice.service.VoiceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,9 +25,15 @@ public class VoiceController {
     private final VoiceService voiceService;
 
     // 음성 파일 업로드 및 STT 처리
-    @PostMapping("/upload")
+    @Operation(summary = "음성 업로드", description = "음성 파일 업로드 및 STT 처리")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공")
+    })
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<TranscribedTextResponse> uploadAudio(
+            @Parameter(description = "음성 파일", content = @Content(mediaType = "multipart/form-data"))
             @RequestParam("audio_file") MultipartFile audioFile,
+            @Parameter(description = "세션 ID")
             @RequestParam("session_id") Long sessionId
 //            @RequestHeader("Authorization") String authHeader
     ) throws IOException {

--- a/src/main/java/com/example/demo/voice/dao/VoiceDao.java
+++ b/src/main/java/com/example/demo/voice/dao/VoiceDao.java
@@ -1,0 +1,4 @@
+package com.example.demo.voice.dao;
+
+public interface VoiceDao {
+}

--- a/src/main/java/com/example/demo/voice/dao/VoiceDao.java
+++ b/src/main/java/com/example/demo/voice/dao/VoiceDao.java
@@ -1,4 +1,15 @@
 package com.example.demo.voice.dao;
 
+import com.example.demo.voice.dto.TtsLogRequest;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
 public interface VoiceDao {
+    // 채팅 메시지 저장 (USER/BOT)
+    void insertChat(@Param("uid") int uid, @Param("role") String role,
+                    @Param("content") String content, @Param("sessionId") Long sessionId);
+
+    // TTS 로그 저장
+    void insertTtsLog(TtsLogRequest request);
 }

--- a/src/main/java/com/example/demo/voice/dto/TranscribedTextResponse.java
+++ b/src/main/java/com/example/demo/voice/dto/TranscribedTextResponse.java
@@ -1,4 +1,18 @@
 package com.example.demo.voice.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class TranscribedTextResponse {
+    private boolean success; // 요청 성공 여부
+    private Data data;       // 변환된 텍스트 및 기타 정보
+
+    @Getter
+    @AllArgsConstructor
+    public static class Data {
+        private String transcribedText; // 변환된 텍스트
+        private String messageId;       // 저장된 메시지 식별자
+    }
 }

--- a/src/main/java/com/example/demo/voice/dto/TranscribedTextResponse.java
+++ b/src/main/java/com/example/demo/voice/dto/TranscribedTextResponse.java
@@ -1,0 +1,4 @@
+package com.example.demo.voice.dto;
+
+public class TranscribedTextResponse {
+}

--- a/src/main/java/com/example/demo/voice/dto/TtsLogRequest.java
+++ b/src/main/java/com/example/demo/voice/dto/TtsLogRequest.java
@@ -1,4 +1,11 @@
 package com.example.demo.voice.dto;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class TtsLogRequest {
+    private int cid;         // chats.cid
+    private String ttsUrl;   // 변환된 음성(mp3) URL
 }

--- a/src/main/java/com/example/demo/voice/dto/TtsLogRequest.java
+++ b/src/main/java/com/example/demo/voice/dto/TtsLogRequest.java
@@ -1,0 +1,4 @@
+package com.example.demo.voice.dto;
+
+public class TtsLogRequest {
+}

--- a/src/main/java/com/example/demo/voice/dto/TtsLogResponse.java
+++ b/src/main/java/com/example/demo/voice/dto/TtsLogResponse.java
@@ -1,4 +1,11 @@
 package com.example.demo.voice.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class TtsLogResponse {
+    private boolean success; // 요청 성공 여부
+    private String message;  // 결과 메시지
 }

--- a/src/main/java/com/example/demo/voice/dto/TtsLogResponse.java
+++ b/src/main/java/com/example/demo/voice/dto/TtsLogResponse.java
@@ -1,0 +1,4 @@
+package com.example.demo.voice.dto;
+
+public class TtsLogResponse {
+}

--- a/src/main/java/com/example/demo/voice/dto/VoiceUploadRequest.java
+++ b/src/main/java/com/example/demo/voice/dto/VoiceUploadRequest.java
@@ -1,0 +1,4 @@
+package com.example.demo.voice.dto;
+
+public class VoiceUploadRequest {
+}

--- a/src/main/java/com/example/demo/voice/dto/VoiceUploadRequest.java
+++ b/src/main/java/com/example/demo/voice/dto/VoiceUploadRequest.java
@@ -1,4 +1,0 @@
-package com.example.demo.voice.dto;
-
-public class VoiceUploadRequest {
-}

--- a/src/main/java/com/example/demo/voice/service/GoogleSttService.java
+++ b/src/main/java/com/example/demo/voice/service/GoogleSttService.java
@@ -1,0 +1,5 @@
+package com.example.demo.voice.service;
+
+public interface GoogleSttService {
+    String transcribe(byte[] audioBytes);
+}

--- a/src/main/java/com/example/demo/voice/service/GoogleSttService.java
+++ b/src/main/java/com/example/demo/voice/service/GoogleSttService.java
@@ -1,5 +1,10 @@
 package com.example.demo.voice.service;
 
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
 public interface GoogleSttService {
-    String transcribe(byte[] audioBytes);
+    String uploadFileToGCS(MultipartFile file) throws IOException;
+    String transcribeAudio(String gcsUri) throws IOException;
 }

--- a/src/main/java/com/example/demo/voice/service/GoogleSttServiceImpl.java
+++ b/src/main/java/com/example/demo/voice/service/GoogleSttServiceImpl.java
@@ -2,15 +2,20 @@ package com.example.demo.voice.service;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.speech.v1.*;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import com.google.protobuf.ByteString;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -19,14 +24,45 @@ public class GoogleSttServiceImpl implements GoogleSttService {
     @Value("${google.credentials-path}")
     private String credentialsPath;
 
+    @Value("${google.bucket-name}")
+    private String bucketName;
+
     private final ResourceLoader resourceLoader;
 
     public GoogleSttServiceImpl(ResourceLoader resourceLoader) {
         this.resourceLoader = resourceLoader;
     }
 
+    // ✅ GCS에 업로드하고 URI 반환
     @Override
-    public String transcribe(byte[] audioBytes) {
+    public String uploadFileToGCS(MultipartFile file) {
+        try {
+            Resource resource = resourceLoader.getResource(credentialsPath);
+            InputStream credentialsStream = resource.getInputStream();
+            GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsStream);
+
+            Storage storage = StorageOptions.newBuilder()
+                    .setCredentials(credentials)
+                    .build()
+                    .getService();
+
+            String fileName = "audio/" + UUID.randomUUID() + "-" + file.getOriginalFilename();
+            BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, fileName)
+                    .setContentType(file.getContentType())
+                    .build();
+
+            storage.create(blobInfo, file.getBytes());
+
+            return String.format("gs://%s/%s", bucketName, fileName);
+        } catch (Exception e) {
+            log.error("GCS 파일 업로드 실패", e);
+            throw new RuntimeException("GCS 파일 업로드 실패");
+        }
+    }
+
+    // ✅ GCS URI로 STT 실행
+    @Override
+    public String transcribeAudio(String gcsUri) {
         try {
             Resource resource = resourceLoader.getResource(credentialsPath);
             InputStream credentialsStream = resource.getInputStream();
@@ -37,14 +73,13 @@ public class GoogleSttServiceImpl implements GoogleSttService {
                     .build();
 
             try (SpeechClient speechClient = SpeechClient.create(settings)) {
-
-                RecognitionAudio audio = RecognitionAudio.newBuilder()
-                        .setContent(ByteString.copyFrom(audioBytes))
-                        .build();
-
                 RecognitionConfig config = RecognitionConfig.newBuilder()
                         .setEncoding(RecognitionConfig.AudioEncoding.LINEAR16)
                         .setLanguageCode("ko-KR")
+                        .build();
+
+                RecognitionAudio audio = RecognitionAudio.newBuilder()
+                        .setUri(gcsUri)
                         .build();
 
                 RecognizeResponse response = speechClient.recognize(config, audio);
@@ -57,7 +92,7 @@ public class GoogleSttServiceImpl implements GoogleSttService {
                 return transcript.toString();
             }
         } catch (Exception e) {
-            log.error("STT 변환 실패", e);
+            log.error("GCS 기반 STT 변환 실패", e);
             return "음성 인식에 실패했습니다.";
         }
     }

--- a/src/main/java/com/example/demo/voice/service/GoogleSttServiceImpl.java
+++ b/src/main/java/com/example/demo/voice/service/GoogleSttServiceImpl.java
@@ -1,0 +1,64 @@
+package com.example.demo.voice.service;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.speech.v1.*;
+import com.google.protobuf.ByteString;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+import java.util.List;
+
+@Slf4j
+@Service
+public class GoogleSttServiceImpl implements GoogleSttService {
+
+    @Value("${google.credentials-path}")
+    private String credentialsPath;
+
+    private final ResourceLoader resourceLoader;
+
+    public GoogleSttServiceImpl(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
+
+    @Override
+    public String transcribe(byte[] audioBytes) {
+        try {
+            Resource resource = resourceLoader.getResource(credentialsPath);
+            InputStream credentialsStream = resource.getInputStream();
+            GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsStream);
+
+            SpeechSettings settings = SpeechSettings.newBuilder()
+                    .setCredentialsProvider(() -> credentials)
+                    .build();
+
+            try (SpeechClient speechClient = SpeechClient.create(settings)) {
+
+                RecognitionAudio audio = RecognitionAudio.newBuilder()
+                        .setContent(ByteString.copyFrom(audioBytes))
+                        .build();
+
+                RecognitionConfig config = RecognitionConfig.newBuilder()
+                        .setEncoding(RecognitionConfig.AudioEncoding.LINEAR16)
+                        .setLanguageCode("ko-KR")
+                        .build();
+
+                RecognizeResponse response = speechClient.recognize(config, audio);
+
+                StringBuilder transcript = new StringBuilder();
+                for (SpeechRecognitionResult result : response.getResultsList()) {
+                    transcript.append(result.getAlternativesList().get(0).getTranscript());
+                }
+
+                return transcript.toString();
+            }
+        } catch (Exception e) {
+            log.error("STT 변환 실패", e);
+            return "음성 인식에 실패했습니다.";
+        }
+    }
+}

--- a/src/main/java/com/example/demo/voice/service/GoogleTtsService.java
+++ b/src/main/java/com/example/demo/voice/service/GoogleTtsService.java
@@ -1,0 +1,5 @@
+package com.example.demo.voice.service;
+
+public interface GoogleTtsService {
+    byte[] synthesizeSpeech(String text); // MP3 binary 반환
+}

--- a/src/main/java/com/example/demo/voice/service/GoogleTtsServiceImpl.java
+++ b/src/main/java/com/example/demo/voice/service/GoogleTtsServiceImpl.java
@@ -1,0 +1,76 @@
+package com.example.demo.voice.service;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.speech.v1.SpeechSettings;
+import com.google.cloud.texttospeech.v1.*;
+import com.google.protobuf.ByteString;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.io.InputStream;
+
+@Slf4j
+@Service
+public class GoogleTtsServiceImpl implements GoogleTtsService {
+
+    @Value("${google.credentials-path}")
+    private String credentialsPath;
+
+    private final ResourceLoader resourceLoader;
+
+    public GoogleTtsServiceImpl(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
+
+    /**
+     * 입력된 텍스트를 Google Cloud Text-to-Speech API를 이용해 음성 데이터(MP3)로 변환
+     *
+     * @param text 변환할 텍스트
+     * @return 음성 데이터 (MP3 형식의 byte 배열)
+     */
+    @Override
+    public byte[] synthesizeSpeech(String text) {
+        try {
+            // 1. 서비스 계정 키 파일을 classpath에서 불러오기
+            Resource resource = resourceLoader.getResource(credentialsPath);
+            InputStream credentialsStream = resource.getInputStream();
+            GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsStream);
+
+            // 2. 자격 증명을 포함한 TTS 클라이언트 설정 구성
+            TextToSpeechSettings settings = TextToSpeechSettings.newBuilder()
+                    .setCredentialsProvider(()  -> credentials)
+                    .build();
+
+            // 3. TTS 클라이언트 생성 및 사용
+            try (TextToSpeechClient client = TextToSpeechClient.create(settings)) {
+                // 4. 변환할 텍스트 설정
+                SynthesisInput input = SynthesisInput.newBuilder().setText(text).build();
+
+                // 5. 사용할 목소리 설정 (한국어, 중립적 음성)
+                VoiceSelectionParams voice = VoiceSelectionParams.newBuilder()
+                        .setLanguageCode("ko-KR")
+                        .setSsmlGender(SsmlVoiceGender.NEUTRAL)
+                        .build();
+                // 6. 출력 오디오 형식 설정 (MP3)
+                AudioConfig audioConfig = AudioConfig.newBuilder()
+                        .setAudioEncoding(AudioEncoding.MP3)
+                        .build();
+
+                // 7. TTS API 호출하여 음성 데이터 생성
+                SynthesizeSpeechResponse response = client.synthesizeSpeech(input, voice, audioConfig);
+                // 8. 응답에서 음성 데이터(byte[]) 추출하여 반환
+                return response.getAudioContent().toByteArray();
+            }
+        } catch (Exception e) {
+            log.error("TTS 변환 실패", e);
+            throw new RuntimeException("TTS 변환 실패", e);
+        }
+    }
+
+
+}

--- a/src/main/java/com/example/demo/voice/service/VoiceService.java
+++ b/src/main/java/com/example/demo/voice/service/VoiceService.java
@@ -9,6 +9,9 @@ public interface VoiceService {
     // 음성 업로드 처리 및 STT → 챗봇 응답 처리
     TranscribedTextResponse handleAudioUpload(MultipartFile file, Long sessionId, String token);
 
+    // 텍스트를 음성으로 변환하여 byte 배열(mp3)을 반환
+    byte[] synthesizeSpeech(String text);
+
     // TTS 로그 저장
     TtsLogResponse saveTtsLog(TtsLogRequest request);
 }

--- a/src/main/java/com/example/demo/voice/service/VoiceService.java
+++ b/src/main/java/com/example/demo/voice/service/VoiceService.java
@@ -1,4 +1,14 @@
 package com.example.demo.voice.service;
 
-public class VoiceService {
+import com.example.demo.voice.dto.TranscribedTextResponse;
+import com.example.demo.voice.dto.TtsLogRequest;
+import com.example.demo.voice.dto.TtsLogResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface VoiceService {
+    // 음성 업로드 처리 및 STT → 챗봇 응답 처리
+    TranscribedTextResponse handleAudioUpload(MultipartFile file, Long sessionId, String token);
+
+    // TTS 로그 저장
+    TtsLogResponse saveTtsLog(TtsLogRequest request);
 }

--- a/src/main/java/com/example/demo/voice/service/VoiceService.java
+++ b/src/main/java/com/example/demo/voice/service/VoiceService.java
@@ -1,0 +1,4 @@
+package com.example.demo.voice.service;
+
+public class VoiceService {
+}

--- a/src/main/java/com/example/demo/voice/service/VoiceServiceImpl.java
+++ b/src/main/java/com/example/demo/voice/service/VoiceServiceImpl.java
@@ -1,0 +1,61 @@
+package com.example.demo.voice.service;
+
+import com.example.demo.chatbot.service.ChatbotService;
+import com.example.demo.login.dao.UserDao;
+import com.example.demo.provider.JwtProvider;
+import com.example.demo.voice.dao.VoiceDao;
+import com.example.demo.voice.dto.TranscribedTextResponse;
+import com.example.demo.voice.dto.TtsLogRequest;
+import com.example.demo.voice.dto.TtsLogResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@Service
+@RequiredArgsConstructor
+public class VoiceServiceImpl implements VoiceService {
+
+    private final VoiceDao voiceDao;
+    private final ChatbotService chatbotService;
+    private final JwtProvider jwtProvider;
+    private final GoogleSttService googleSttService;
+    private final UserDao userDao;
+
+    @Override
+    public TranscribedTextResponse handleAudioUpload(MultipartFile file, Long sessionId, String token) {
+        try {
+            // 1. 이메일 추출
+//            String email = jwtProvider.getEmail(token);
+
+            // 2. uid 조회
+//            int uid = userDao.findByEmail(email).getUid().intValue();
+
+            // 3. STT 처리
+            byte[] audioBytes = file.getBytes(); // IOException 발생 가능
+            String text = googleSttService.transcribe(audioBytes);
+
+            // 4. 챗봇 연동 및 DB 저장
+//            voiceDao.insertChat(uid, "USER", text, sessionId);
+//            String botResponse = chatbotService.askOnce(text);
+//            voiceDao.insertChat(uid, "BOT", botResponse, sessionId);
+
+            return new TranscribedTextResponse(true,
+                    new TranscribedTextResponse.Data(text, "msg_session_" + sessionId));
+
+        } catch (IOException e) {
+            throw new RuntimeException("음성 파일 처리 중 오류가 발생했습니다.", e);
+//        } catch (SQLException e) {
+//            throw new RuntimeException("사용자 정보를 조회하는 중 오류가 발생했습니다.", e);
+        }
+    }
+
+
+    @Override
+    public TtsLogResponse saveTtsLog(TtsLogRequest request) {
+        voiceDao.insertTtsLog(request);
+        return new TtsLogResponse(true, "로그 저장 완료");
+    }
+}

--- a/src/main/java/com/example/demo/voice/service/VoiceServiceImpl.java
+++ b/src/main/java/com/example/demo/voice/service/VoiceServiceImpl.java
@@ -23,7 +23,11 @@ public class VoiceServiceImpl implements VoiceService {
     private final JwtProvider jwtProvider;
     private final GoogleSttService googleSttService;
     private final UserDao userDao;
+    private final GoogleTtsService googleTtsService;
 
+    /*
+    음성 파일 업로드 및 STT 처리 -> 텍스트 추출 후 챗봇 응답 요청까지
+     */
     @Override
     public TranscribedTextResponse handleAudioUpload(MultipartFile file, Long sessionId, String token) {
         try {
@@ -56,7 +60,17 @@ public class VoiceServiceImpl implements VoiceService {
         }
     }
 
+    /*
+    텍스트를 음성 (MP3 바이트)로 변환
+     */
+    @Override
+    public byte[] synthesizeSpeech(String text) {
+        return googleTtsService.synthesizeSpeech(text);
+    }
 
+    /*
+    TTS 로그를 DB에 저장
+     */
     @Override
     public TtsLogResponse saveTtsLog(TtsLogRequest request) {
         voiceDao.insertTtsLog(request);

--- a/src/main/resources/mapper/Voice.xml
+++ b/src/main/resources/mapper/Voice.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.example.demo.voice.dao.VoiceDao">
+
+    <!-- chats 테이블에 채팅 메시지 저장 -->
+    <insert id="insertChat" parameterType="map">
+        INSERT INTO chats (uid, role, content, session_id, created_at)
+        VALUES (#{uid}, #{role}, #{content}, #{sessionId}, NOW());
+    </insert>
+
+    <!-- tts_log 테이블에 변환된 음성 URL 저장 -->
+    <insert id="insertTtsLog" parameterType="map">
+        INSERT INTO tts_log (cid, ttsUrl, created_at)
+        VALUES (#{cid}, #{ttsUrl}, NOW());
+    </insert>
+
+</mapper>


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
STT(음성 인식) 및 TTS(음성 합성) 기능을 구현하여 사용자의 음성 입력을 텍스트로 변환해서 챗봇에 넘겨주고, 챗봇 응답을 음성으로 출력하는 기능을 완성함

### 주요 구현 내용
1. STT (Speech-to-Text)

- POST /chat/voice/upload: 사용자가 음성 파일 업로드 시 GCS(Google Cloud Storage)에 업로드
- 업로드된 파일을 기반으로 Google Cloud Speech-to-Text API를 사용해 텍스트로 변환
- 변환된 텍스트를 챗봇에 전달하고, 사용자 입력으로 응답을 받아 응답 로그 출력
- 서비스 계정 키를 기반으로 인증 처리

2. TTS (Text-to-Speech)

- GET /chat/voice/tts?text=문자열: 전달된 텍스트를 Google Cloud Text-to-Speech API를 이용해 MP3 형식으로 변환
- 응답으로 audio/mpeg 타입의 음성 바이너리를 반환하여, 클라이언트 측에서 바로 재생 가능
- 서비스 계정 키를 기반으로 인증 처리

## 테스트
<!-- 테스트 방법 간략하게 작성 -->
### 🔉 STT 테스트 (/chat/voice/upload)
1. Swagger 또는 Postman에서 POST /chat/voice/upload 호출

2. audio_file에 .wav 또는 .mp3 파일 업로드

3. session_id 파라미터와 함께 요청 시 변환된 텍스트가 JSON 형태로 응답됨
<img width="1446" alt="스크린샷 2025-06-16 오후 3 43 36" src="https://github.com/user-attachments/assets/686aaad2-672e-42a2-a658-1f61e1557df7" />
<img width="1418" alt="스크린샷 2025-06-16 오후 3 44 11" src="https://github.com/user-attachments/assets/c7db3a5a-a26d-445b-9217-01f9f24cfeb7" />

### 🗣️ TTS 테스트 (/chat/voice/tts)
1. Swagger에서 GET /chat/voice/tts?text=테스트음성 호출

2. 브라우저 또는 오디오 플레이어에서 음성이 정상적으로 재생됨
<img width="1423" alt="스크린샷 2025-06-16 오후 3 45 55" src="https://github.com/user-attachments/assets/141d0382-6411-4703-b4ce-261729609bde" />

## 이슈
<!-- 관련 이슈 번호 (PR 병합 시 자동으로 이슈가 닫히도록 'closes #이슈번호' 형식 사용) -->

- 현재는 STT 결과를 기반으로 챗봇에 질문을 전달하되, DB에는 저장하지 않음

- 추후 STT 처리된 질문 내용을 DB에 어떻게 저장할 지는 논의 후 추가해야 됨
