### PR TITLE
CHAM-64 FEAT: 챗봇 이전 대화 기억 기능 구현

### DIFF
--- a/src/main/java/com/example/demo/chatbot/dao/ChatbotDao.java
+++ b/src/main/java/com/example/demo/chatbot/dao/ChatbotDao.java
@@ -1,0 +1,14 @@
+package com.example.demo.chatbot.dao;
+
+import com.example.demo.chatbot.dto.Chatting;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.sql.SQLException;
+import java.util.List;
+
+@Mapper
+public interface ChatbotDao {
+    int insertChatting(Chatting chatting)throws SQLException;
+    List<Chatting> selectChatting(@Param("session_id") String sessionId);
+}

--- a/src/main/java/com/example/demo/chatbot/dto/ChatCompletionChunk.java
+++ b/src/main/java/com/example/demo/chatbot/dto/ChatCompletionChunk.java
@@ -1,0 +1,37 @@
+package com.example.demo.chatbot.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChatCompletionChunk {
+    private String id;
+    private String object;
+    private long created;
+    private String model;
+    private List<Choice> choices;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Choice {
+        private Delta delta;
+        private int index;
+
+        @JsonProperty("finish_reason")
+        private String finishReason;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Delta {
+        /** 최초 청크에만 오고 이후엔 null */
+        private String role;
+
+        /** 이후 스트리밍 되는 텍스트 델타 */
+        private String content;
+    }
+}

--- a/src/main/java/com/example/demo/chatbot/dto/Chatting.java
+++ b/src/main/java/com/example/demo/chatbot/dto/Chatting.java
@@ -1,0 +1,14 @@
+package com.example.demo.chatbot.dto;
+
+import lombok.*;
+
+@Data
+@RequiredArgsConstructor
+public class Chatting {
+    private Long cid;
+    private Long uid;
+    private String role;
+    private String content;
+    private String created_at;
+    private String session_id;
+}

--- a/src/main/java/com/example/demo/chatbot/dto/Chatting.java
+++ b/src/main/java/com/example/demo/chatbot/dto/Chatting.java
@@ -1,5 +1,6 @@
 package com.example.demo.chatbot.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 @Data
@@ -9,6 +10,8 @@ public class Chatting {
     private Long uid;
     private String role;
     private String content;
-    private String created_at;
-    private String session_id;
+    @JsonProperty("created_at")
+    private String createdAt;
+    @JsonProperty("session_id")
+    private String sessionId;
 }

--- a/src/main/java/com/example/demo/chatbot/dto/RagSource.java
+++ b/src/main/java/com/example/demo/chatbot/dto/RagSource.java
@@ -1,0 +1,11 @@
+package com.example.demo.chatbot.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class RagSource {
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/example/demo/chatbot/service/Chatbot.java
+++ b/src/main/java/com/example/demo/chatbot/service/Chatbot.java
@@ -1,9 +1,15 @@
 package com.example.demo.chatbot.service;
 
+import com.example.demo.chatbot.dto.Chatting;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.http.ResponseEntity;
 
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 public interface Chatbot {
-    public void streamChatting(String prompt, Consumer<String> consumer) throws JsonProcessingException;
+    public void streamChatting(List<Map<String, String>> messages, String sessionId, Consumer<String> consumer) throws JsonProcessingException;
+    public List<Chatting> getChattingList(String sessionId);
+    public ResponseEntity<String> storeChatting(Chatting chatting);
 }

--- a/src/main/java/com/example/demo/chatbot/service/ChatbotService.java
+++ b/src/main/java/com/example/demo/chatbot/service/ChatbotService.java
@@ -45,7 +45,7 @@ public class ChatbotService implements Chatbot{
         userChat.setUid(userId);
         userChat.setRole("user");
         userChat.setContent(userContent);
-        userChat.setSession_id(sessionId);
+        userChat.setSessionId(sessionId);
         try {
             chatbotDao.insertChatting(userChat);
         } catch (Exception e) {
@@ -110,7 +110,7 @@ public class ChatbotService implements Chatbot{
                 aiChat.setUid(userId);
                 aiChat.setRole("assistant");
                 aiChat.setContent(aiBuilder.toString());
-                aiChat.setSession_id(sessionId);
+                aiChat.setSessionId(sessionId);
                 try {
                     chatbotDao.insertChatting(aiChat);
                 } catch (Exception e) {

--- a/src/main/java/com/example/demo/chatbot/service/ChatbotService.java
+++ b/src/main/java/com/example/demo/chatbot/service/ChatbotService.java
@@ -1,35 +1,62 @@
 package com.example.demo.chatbot.service;
 
+import com.example.demo.chatbot.dao.ChatbotDao;
+import com.example.demo.chatbot.dto.ChatCompletionChunk;
+import com.example.demo.chatbot.dto.Chatting;
+import com.example.demo.login.service.AuthenticationService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
+import org.springframework.util.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class ChatbotService implements Chatbot{
     private final OkHttpClient client = new OkHttpClient();
+    private final ChatbotDao chatbotDao;
 
     @Value("${openai.key}")
     private String OPENAI_API_KEY;
     @Value("${openai.model}")
     private String MODEL;
-    @Override
-    public void streamChatting(String prompt, Consumer<String> consumer) throws JsonProcessingException {
 
+    private final AuthenticationService authenticationService;
+    @Override
+    public void streamChatting(List<Map<String, String>> messages, String sessionId, Consumer<String> consumer) throws JsonProcessingException {
+        Long userId = authenticationService.getCurrentUserId();
+        String userContent = messages.get(messages.size() - 1).get("content");
+        Chatting userChat = new Chatting();
+        userChat.setUid(userId);
+        userChat.setRole("user");
+        userChat.setContent(userContent);
+        userChat.setSession_id(sessionId);
+        try {
+            chatbotDao.insertChatting(userChat);
+        } catch (Exception e) {
+            log.warn("유저 채팅 저장 실패: {}", e.getMessage());
+        }
+        System.out.println(messages);
         ObjectMapper mapper = new ObjectMapper();
         Map<String, Object> payload = new HashMap<>();
         payload.put("model", MODEL);
         payload.put("stream", true);
-        payload.put("messages", List.of(Map.of("role", "user", "content", prompt)));
+        payload.put("messages", messages);
 
         String jsonBody = mapper.writeValueAsString(payload);
 
@@ -39,7 +66,7 @@ public class ChatbotService implements Chatbot{
                 .addHeader("Content-Type", "application/json")
                 .post(RequestBody.create(jsonBody, MediaType.get("application/json")))
                 .build();
-
+        StringBuilder aiBuilder = new StringBuilder();
         client.newCall(request).enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
@@ -48,20 +75,82 @@ public class ChatbotService implements Chatbot{
 
             @Override
             public void onResponse(Call call, Response response) {
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.body().byteStream()))) {
+                StringBuilder aiBuilder = new StringBuilder();
+
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(response.body().byteStream()))) {
+
                     String line;
                     while ((line = reader.readLine()) != null) {
-                        if (line.startsWith("data: ")) {
-                            String json = line.substring(6).trim();
-                            if (!json.equals("[DONE]")) {
-                                consumer.accept(json);
-                            }
+                        if (!line.startsWith("data: ")) continue;
+                        String json = line.substring(6).trim();
+
+                        // JSON 파싱
+                        ChatCompletionChunk chunk = mapper.readValue(json, ChatCompletionChunk.class);
+                        var choice = chunk.getChoices().get(0);
+
+                        // 1) 델타가 오면 누적하고 즉시 클라이언트로 전송
+                        String delta = choice.getDelta().getContent();
+                        if (delta != null && !delta.isBlank()) {
+                            aiBuilder.append(delta);
+                            consumer.accept(json);
+                        }
+
+                        // 2) finish_reason 이 나오면 스트림 종료 플래그
+                        if (choice.getFinishReason() != null) {
+                            consumer.accept(json);
+                            break;
                         }
                     }
+
                 } catch (Exception e) {
                     consumer.accept("[ERROR] " + e.getMessage());
                 }
+                Chatting aiChat = new Chatting();
+                aiChat.setUid(userId);
+                aiChat.setRole("assistant");
+                aiChat.setContent(aiBuilder.toString());
+                aiChat.setSession_id(sessionId);
+                try {
+                    chatbotDao.insertChatting(aiChat);
+                } catch (Exception e) {
+                    log.warn("AI 채팅 저장 실패: {}", e.getMessage());
+                }
             }
         });
+    }
+
+    @Override
+    public List<Chatting> getChattingList(String sessionId) {
+        // 1) 파라미터 검증
+        if (!StringUtils.hasText(sessionId)) {
+            return Collections.emptyList();
+        }
+        try {
+            List<Chatting> chats = chatbotDao.selectChatting(sessionId);
+            // 2) 결과 없음 → 빈 리스트 반환
+            if (chats == null || chats.isEmpty()) {
+                return Collections.emptyList();
+            }
+            // 3) 정상 처리
+            return chats;
+
+        } catch (Exception e) {
+            // 4) 예외 처리: 로깅 후 빈 리스트 반환
+            log.error("채팅 조회 실패. sessionId={}, error={}", sessionId, e.getMessage(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public ResponseEntity<String> storeChatting(Chatting chatting) {
+        try {
+            chatbotDao.insertChatting(chatting);
+            return ResponseEntity.ok("SUCCESS");
+        } catch (Exception e) {
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("저장 실패: " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/authorize", "/oauth2/callback/kakao", "/logout", "/kakao", "/refresh").permitAll()
+                        .requestMatchers("/authorize", "/oauth2/callback/kakao", "/logout", "/kakao", "/refresh", "/chat").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/resources/mapper/Chatbot.xml
+++ b/src/main/resources/mapper/Chatbot.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!-- namespace는 패키지 포함한 mapper(DAO interface) 이름으로 설정 한다. -->
+<mapper namespace="com.example.demo.chatbot.dao.ChatbotDao">
+    <insert id="insertChatting"
+            parameterType="com.example.demo.chatbot.dto.Chatting"
+            useGeneratedKeys="true" keyProperty="cid">
+        INSERT INTO chats (uid, role, content, session_id)
+        VALUES (#{uid}, #{role}, #{content}, #{session_id})
+    </insert>
+    <select id="selectChatting"
+            parameterType="String"
+            resultType="com.example.demo.chatbot.dto.Chatting">
+        SELECT
+            cid,
+            uid,
+            role,
+            content,
+            created_at,
+            session_id
+        FROM chats
+        WHERE session_id = #{session_id}
+        ORDER BY created_at DESC
+            LIMIT 20
+    </select>
+</mapper>


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
![image](https://github.com/user-attachments/assets/c4e560d5-a60b-417f-9120-9debea9c64ca)
사진으로 설명할게요
## 테스트
<!-- 테스트 방법 간략하게 작성 -->
1. 이전 20개의 대화를 자동으로 기억함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for session-based chat history, allowing users to retrieve and view previous chat messages by session.
  - Introduced endpoints to store and retrieve chat messages, enabling persistent chat conversations.
  - Enhanced chat streaming to include context from prior messages for more coherent conversations.
  - Integrated user authentication with chat message storage and retrieval.

- **Bug Fixes**
  - Improved error handling for chat streaming and message storage operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->