### PR TITLE
CHAM-55 TTS 변환 결과 GCS업로드 + DB에 log저장

### DIFF
--- a/src/main/java/com/example/demo/gcs/GcsDownloader.java
+++ b/src/main/java/com/example/demo/gcs/GcsDownloader.java
@@ -1,0 +1,65 @@
+package com.example.demo.gcs;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+
+@Component
+public class GcsDownloader {
+
+    @Value("${google.credentials-path}")
+    private String credentialsPath;
+
+    private final ResourceLoader resourceLoader;
+
+    public GcsDownloader(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
+
+    public byte[] download(String gcsUrl) {
+        try {
+            String bucketName;
+            String objectName;
+
+            if (gcsUrl.startsWith("gs://")) {
+                // gs:// 형식 처리
+                String[] parts = gcsUrl.replace("gs://", "").split("/", 2);
+                bucketName = parts[0];
+                objectName = parts[1];
+            } else if (gcsUrl.startsWith("https://storage.googleapis.com/")) {
+                // https:// 형식 처리
+                String path = gcsUrl.replace("https://storage.googleapis.com/", "");
+                String[] parts = path.split("/", 2);
+                bucketName = parts[0];
+                objectName = parts[1];
+            } else {
+                throw new IllegalArgumentException("지원하지 않는 GCS URL 형식입니다: " + gcsUrl);
+            }
+
+            InputStream credentialsStream = resourceLoader.getResource(credentialsPath).getInputStream();
+            GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsStream);
+
+            Storage storage = StorageOptions.newBuilder()
+                    .setCredentials(credentials)
+                    .build()
+                    .getService();
+
+            Blob blob = storage.get(bucketName, objectName);
+            if (blob == null) {
+                throw new RuntimeException("GCS 객체를 찾을 수 없습니다: " + objectName);
+            }
+            byte[] content = blob.getContent();
+            System.out.println("mp3 길이 : "+content.length);
+
+            return content;
+
+        } catch (Exception e) {
+            throw new RuntimeException("GCS 다운로드 실패", e);
+        }
+    }
+
+}

--- a/src/main/java/com/example/demo/gcs/GcsUploader.java
+++ b/src/main/java/com/example/demo/gcs/GcsUploader.java
@@ -1,0 +1,61 @@
+package com.example.demo.gcs;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+
+@Component
+@RequiredArgsConstructor
+public class GcsUploader {
+
+    private final ResourceLoader resourceLoader;
+
+    @Value("${google.credentials-path}")
+    private String credentialsPath;
+
+    @Value("${google.bucket-name}")
+    private String bucketName;
+
+    private Storage storage;
+
+    private void initStorage() throws Exception {
+        if (storage == null) {
+            InputStream credentialsStream = resourceLoader.getResource(credentialsPath).getInputStream();
+            GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsStream);
+            storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService();
+        }
+    }
+
+    public String upload(byte[] data, String objectName) {
+        try {
+            initStorage();
+            BlobId blobId = BlobId.of(bucketName, objectName);
+            BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("audio/mpeg").build();
+            storage.create(blobInfo, data);
+            return String.format("https://storage.googleapis.com/%s/%s", bucketName, objectName);
+        } catch (Exception e) {
+            throw new RuntimeException("GCS 업로드 실패", e);
+        }
+    }
+
+    // 파일 업로드 메서드
+    public String upload(File file, String objectName) {
+        try {
+            initStorage();
+            BlobId blobId = BlobId.of(bucketName, objectName);
+            BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("audio/wav").build();
+            storage.create(blobInfo, Files.readAllBytes(file.toPath()));
+            return String.format("gs://%s/%s", bucketName, objectName);
+        } catch (Exception e) {
+            throw new RuntimeException("GCS 업로드 실패", e);
+        }
+    }
+
+}

--- a/src/main/java/com/example/demo/surveyResult/service/SurveyService.java
+++ b/src/main/java/com/example/demo/surveyResult/service/SurveyService.java
@@ -32,4 +32,8 @@ public class SurveyService {
     public SurveyResponseDto selectedBugId(int bugId){
         return surveyMapper.selectedBugId(bugId);
     }
+
+    public SurveyResponseDto selectedBugId(int bugId){
+        return surveyMapper.selectedBugId(bugId);
+    }
 }

--- a/src/main/java/com/example/demo/voice/controller/VoiceController.java
+++ b/src/main/java/com/example/demo/voice/controller/VoiceController.java
@@ -42,18 +42,12 @@ public class VoiceController {
         return ResponseEntity.ok(response);
     }
 
-    // TTS 스트리밍
-    @GetMapping(value = "/tts", produces = "audio/mpeg")
-    public ResponseEntity<byte[]> tts(@RequestParam String text) {
-        byte[] mp3Data = voiceService.synthesizeSpeech(text);
+    // TTS 변환 및 스트리밍, 저장
+    @GetMapping(value = "/tts/{cid}", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public ResponseEntity<byte[]> streamTts(@PathVariable int cid) {
+        byte[] audio = voiceService.getTtsAudioByCid(cid);
         return ResponseEntity.ok()
                 .contentType(MediaType.valueOf("audio/mpeg"))
-                .body(mp3Data);
-    }
-
-    // TTS 로그 저장
-    @PostMapping("/tts-log")
-    public ResponseEntity<TtsLogResponse> saveTtsLog(@RequestBody TtsLogRequest request) {
-        return ResponseEntity.ok(voiceService.saveTtsLog(request));
+                .body(audio);
     }
 }

--- a/src/main/java/com/example/demo/voice/dao/VoiceDao.java
+++ b/src/main/java/com/example/demo/voice/dao/VoiceDao.java
@@ -7,9 +7,15 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface VoiceDao {
     // 채팅 메시지 저장 (USER/BOT)
-    void insertChat(@Param("uid") int uid, @Param("role") String role,
-                    @Param("content") String content, @Param("sessionId") Long sessionId);
+//    void insertChat(@Param("uid") int uid, @Param("role") String role,
+//                    @Param("content") String content, @Param("sessionId") Long sessionId);
 
     // TTS 로그 저장
     void insertTtsLog(TtsLogRequest request);
+
+    // cid로 GCS URL 조회
+    String findTtsUrlByCid(@Param("cid") int cid);
+
+    // cid로 텍스트(content) 조회
+    String findChatTextByCid(@Param("cid") int cid);
 }

--- a/src/main/java/com/example/demo/voice/dto/TtsLogRequest.java
+++ b/src/main/java/com/example/demo/voice/dto/TtsLogRequest.java
@@ -1,10 +1,14 @@
 package com.example.demo.voice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class TtsLogRequest {
     private int cid;         // chats.cid
     private String ttsUrl;   // 변환된 음성(mp3) URL

--- a/src/main/java/com/example/demo/voice/service/VoiceService.java
+++ b/src/main/java/com/example/demo/voice/service/VoiceService.java
@@ -9,9 +9,9 @@ public interface VoiceService {
     // 음성 업로드 처리 및 STT → 챗봇 응답 처리
     TranscribedTextResponse handleAudioUpload(MultipartFile file, Long sessionId, String token);
 
-    // 텍스트를 음성으로 변환하여 byte 배열(mp3)을 반환
-    byte[] synthesizeSpeech(String text);
+    // 텍스트 -> 음성 변환 + 저장
+    TtsLogResponse convertAndLogTts(int cid, String text);
 
-    // TTS 로그 저장
-    TtsLogResponse saveTtsLog(TtsLogRequest request);
+    // 변환된 음성(mp3) 응답
+    byte[] getTtsAudioByCid(int cid);
 }

--- a/src/main/java/com/example/demo/voice/service/VoiceServiceImpl.java
+++ b/src/main/java/com/example/demo/voice/service/VoiceServiceImpl.java
@@ -1,6 +1,8 @@
 package com.example.demo.voice.service;
 
 import com.example.demo.chatbot.service.ChatbotService;
+import com.example.demo.gcs.GcsDownloader;
+import com.example.demo.gcs.GcsUploader;
 import com.example.demo.login.dao.UserDao;
 import com.example.demo.provider.JwtProvider;
 import com.example.demo.voice.dao.VoiceDao;
@@ -13,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +27,8 @@ public class VoiceServiceImpl implements VoiceService {
     private final GoogleSttService googleSttService;
     private final UserDao userDao;
     private final GoogleTtsService googleTtsService;
+    private final GcsUploader gcsUploader;
+    private final GcsDownloader gcsDownloader;
 
     /*
     음성 파일 업로드 및 STT 처리 -> 텍스트 추출 후 챗봇 응답 요청까지
@@ -59,20 +64,40 @@ public class VoiceServiceImpl implements VoiceService {
         }
     }
 
-    /*
-    텍스트를 음성 (MP3 바이트)로 변환
-     */
     @Override
-    public byte[] synthesizeSpeech(String text) {
-        return googleTtsService.synthesizeSpeech(text);
+    public TtsLogResponse convertAndLogTts(int cid, String text) {
+        byte[] mp3Data = googleTtsService.synthesizeSpeech(text);
+
+        //로그 확인용
+        System.out.println("음성파일 길이 : " + mp3Data.length);
+
+        // 1. GCS에 업로드
+        String ttsUrl = gcsUploader.upload(mp3Data, "tts/" + UUID.randomUUID() + ".mp3");
+
+        // 2. DB 저장
+        voiceDao.insertTtsLog(new TtsLogRequest(cid, ttsUrl));
+        return new TtsLogResponse(true, "TTS 저장 완료");
     }
 
-    /*
-    TTS 로그를 DB에 저장
-     */
     @Override
-    public TtsLogResponse saveTtsLog(TtsLogRequest request) {
-        voiceDao.insertTtsLog(request);
-        return new TtsLogResponse(true, "로그 저장 완료");
+    public byte[] getTtsAudioByCid(int cid) {
+        String ttsUrl = voiceDao.findTtsUrlByCid(cid);
+
+        if (ttsUrl == null) {
+            // 1. DB에서 텍스트 가져오기 (예: chats 테이블)
+            String text = voiceDao.findChatTextByCid(cid);
+            if (text == null || text.isBlank()) {
+                throw new RuntimeException("cid에 해당하는 텍스트가 없습니다.");
+            }
+
+            // 2. convertAndLogTts 호출로 생성 & 저장
+            convertAndLogTts(cid, text);
+
+            // 3. 다시 URL 조회
+            ttsUrl = voiceDao.findTtsUrlByCid(cid);
+        }
+
+        return gcsDownloader.download(ttsUrl);
     }
+
 }

--- a/src/main/java/com/example/demo/voice/service/VoiceServiceImpl.java
+++ b/src/main/java/com/example/demo/voice/service/VoiceServiceImpl.java
@@ -43,14 +43,13 @@ public class VoiceServiceImpl implements VoiceService {
             // 4. GCS 기반 STT 처리 → 텍스트 반환
             String text = googleSttService.transcribeAudio(gcsUri);
 
+            // 6. 챗봇에 질문 전달
+//            chatbotService.streamChatting(text, partial -> {
+//                // 응답 스트리밍 콜백 – 지금은 무시하거나, log만 찍기
+//                System.out.println("[챗봇 응답 일부]: " + partial);
+//            });
 
-            // 5. 챗봇에 질문 전달 (응답 db에 저장하는건 아직 구현 안함)
-            chatbotService.streamChatting(text, partial -> {
-                // 응답 스트리밍 콜백 – 지금은 무시하거나, log만 찍기
-                System.out.println("[챗봇 응답 일부]: " + partial);
-            });
-
-            // 6. 사용자 질문만 응답에 담아 리턴
+            // 7. 사용자 질문만 응답에 담아 리턴
             return new TranscribedTextResponse(true,
                     new TranscribedTextResponse.Data(text, "msg_session_" + sessionId));
         } catch (IOException e) {

--- a/src/main/resources/mapper/Voice.xml
+++ b/src/main/resources/mapper/Voice.xml
@@ -5,16 +5,19 @@
 
 <mapper namespace="com.example.demo.voice.dao.VoiceDao">
 
-    <!-- chats 테이블에 채팅 메시지 저장 -->
-    <insert id="insertChat" parameterType="map">
-        INSERT INTO chats (uid, role, content, session_id, created_at)
-        VALUES (#{uid}, #{role}, #{content}, #{sessionId}, NOW());
-    </insert>
-
     <!-- tts_log 테이블에 변환된 음성 URL 저장 -->
-    <insert id="insertTtsLog" parameterType="map">
-        INSERT INTO tts_log (cid, ttsUrl, created_at)
+    <insert id="insertTtsLog" parameterType="com.example.demo.voice.dto.TtsLogRequest">
+        INSERT INTO tts_log (cid, tts_url, created_at)
         VALUES (#{cid}, #{ttsUrl}, NOW());
     </insert>
 
+    <!-- cid로 GCS URL 조회 -->
+    <select id="findTtsUrlByCid" resultType="String">
+        SELECT tts_url FROM tts_log WHERE cid = #{cid}
+    </select>
+
+    <!-- cid로 텍스트 조회 -->
+    <select id="findChatTextByCid" resultType="String">
+        SELECT content FROM chats WHERE cid = #{cid}
+    </select>
 </mapper>


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
- 사용자의 텍스트 응답을 Google TTS로 변환하여 mp3 데이터를 생성하고 GCS에 업로드

- 업로드된 mp3 파일의 GCS URL을 tts_log 테이블에 저장하여 후속 요청에서 재사용 가능하도록 구현

- cid로 요청 시 TTS URL이 없으면 자동으로 변환 + 저장되도록 처리

- 기존 GCS 업로드/다운로드 로직을 `GcsUploader`, `GcsDownloader` 유틸 클래스로 분리하여 재사용성 향상

- STT 처리 쪽에도 동일한 업로더 유틸 적용하여 중복 제거

## 테스트
<!-- 테스트 방법 간략하게 작성 -->
1. Swagger에서 `/chat/voice/tts/{cid}` 호출 시
 - tts_log에 해당 cid가 없으면 → TTS 변환 → mp3 GCS 업로드 → DB 저장 → 음성 응답
 - tts_log에 해당 cid가 있으면 → GCS에서 mp3 다운로드 → 응답

2. GCS 버킷에서 업로드 확인 및 파일 직접 재생 테스트 완료

<img width="940" alt="스크린샷 2025-06-19 오전 10 56 02" src="https://github.com/user-attachments/assets/421386e8-a7e4-4dbb-9189-38f259edbe45" />

## 이슈
<!-- 관련 이슈 번호 (PR 병합 시 자동으로 이슈가 닫히도록 'closes #이슈번호' 형식 사용) -->
closes #
