### PR TITLE
CHAM-84 FEAT: 가족 모드 활성화 시 RAG 데이터를 불러옴, requestParam에 가족 구성원의 수 추가

### DIFF
--- a/src/main/java/com/example/demo/chatbot/controller/ChatbotController.java
+++ b/src/main/java/com/example/demo/chatbot/controller/ChatbotController.java
@@ -24,7 +24,7 @@ public class ChatbotController {
     private final AuthenticationService authenticationService;
     private final ChatbotDao chatbotDao;
     @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter stream(@RequestParam String prompt, @RequestParam String sessionId, @RequestParam Long members) throws JsonProcessingException {
+    public SseEmitter stream(@RequestParam String prompt, @RequestParam String sessionId, @RequestParam(defaultValue = "1") Long members) throws JsonProcessingException {
         SseEmitter emitter = new SseEmitter();
         List<Chatting> history = chatbotDao.selectChatting(sessionId);
         Collections.reverse(history);

--- a/src/main/java/com/example/demo/chatbot/controller/ChatbotController.java
+++ b/src/main/java/com/example/demo/chatbot/controller/ChatbotController.java
@@ -24,7 +24,7 @@ public class ChatbotController {
     private final AuthenticationService authenticationService;
     private final ChatbotDao chatbotDao;
     @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter stream(@RequestParam String prompt, @RequestParam String sessionId) throws JsonProcessingException {
+    public SseEmitter stream(@RequestParam String prompt, @RequestParam String sessionId, @RequestParam Long members) throws JsonProcessingException {
         SseEmitter emitter = new SseEmitter();
         List<Chatting> history = chatbotDao.selectChatting(sessionId);
         Collections.reverse(history);
@@ -34,7 +34,7 @@ public class ChatbotController {
             messages.add(Map.of("role", role, "content", c.getContent()));
         }
         messages.add(Map.of("role", "user", "content", prompt));
-        chatbotService.streamChatting(messages, sessionId, chunk -> {
+        chatbotService.streamChatting(messages, sessionId, members, chunk -> {
             try {
                 emitter.send(chunk);
             } catch (Exception e) {

--- a/src/main/java/com/example/demo/chatbot/dao/ChatbotDao.java
+++ b/src/main/java/com/example/demo/chatbot/dao/ChatbotDao.java
@@ -1,6 +1,7 @@
 package com.example.demo.chatbot.dao;
 
 import com.example.demo.chatbot.dto.Chatting;
+import com.example.demo.chatbot.dto.RagSource;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -11,4 +12,5 @@ import java.util.List;
 public interface ChatbotDao {
     int insertChatting(Chatting chatting)throws SQLException;
     List<Chatting> selectChatting(@Param("sessionId") String sessionId);
+    List<RagSource> getRagSource();
 }

--- a/src/main/java/com/example/demo/chatbot/dto/RagSource.java
+++ b/src/main/java/com/example/demo/chatbot/dto/RagSource.java
@@ -7,5 +7,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class RagSource {
     private String title;
+    private String section;
     private String content;
 }

--- a/src/main/java/com/example/demo/chatbot/service/Chatbot.java
+++ b/src/main/java/com/example/demo/chatbot/service/Chatbot.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 public interface Chatbot {
-    public void streamChatting(List<Map<String, String>> messages, String sessionId, Consumer<String> consumer) throws JsonProcessingException;
+    public void streamChatting(List<Map<String, String>> messages, String sessionId, Long members, Consumer<String> consumer) throws JsonProcessingException;
     public List<Chatting> getChattingList(String sessionId);
     public ResponseEntity<String> storeChatting(Chatting chatting);
 }

--- a/src/main/resources/mapper/Chatbot.xml
+++ b/src/main/resources/mapper/Chatbot.xml
@@ -25,4 +25,7 @@
         ORDER BY created_at DESC
             LIMIT 20
     </select>
+    <select id="getRagSource">
+        SELECT * FROM rag_source_data
+    </select>
 </mapper>


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
![image](https://github.com/user-attachments/assets/992aa34f-7abc-4285-b27f-a1c43585cb32)

![image](https://github.com/user-attachments/assets/fa5a63c0-2691-4320-b38d-333e53326d3d)

client에서 가족 구성원의 숫자가 2명 이상일 때 가족 RAG 데이터를 불러온 후 system prompt로 가공

## 테스트
<!-- 테스트 방법 간략하게 작성 -->
1. 클라이언트에서 가족 모드 활성화
2. 챗봇과 대화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced chat streaming to include additional context when multiple members are present in a session.
- **Improvements**
  - Expanded chatbot capabilities by integrating additional data sources for richer responses in group chats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->