### PR TITLE
CHAM-55 채팅 스트리밍 응답에 cid 포함 기능 추가

### DIFF
--- a/src/main/java/com/example/demo/chatbot/service/ChatbotService.java
+++ b/src/main/java/com/example/demo/chatbot/service/ChatbotService.java
@@ -96,9 +96,54 @@ public class ChatbotService implements Chatbot{
                 consumer.accept("[ERROR] " + e.getMessage());
             }
 
+//            @Override
+//            public void onResponse(Call call, Response response) {
+//                StringBuilder aiBuilder = new StringBuilder();
+//
+//                try (BufferedReader reader = new BufferedReader(
+//                        new InputStreamReader(response.body().byteStream()))) {
+//
+//                    String line;
+//                    while ((line = reader.readLine()) != null) {
+//                        if (!line.startsWith("data: ")) continue;
+//                        String json = line.substring(6).trim();
+//
+//                        // JSON 파싱
+//                        ChatCompletionChunk chunk = mapper.readValue(json, ChatCompletionChunk.class);
+//                        var choice = chunk.getChoices().get(0);
+//
+//                        // 1) 델타가 오면 누적하고 즉시 클라이언트로 전송
+//                        String delta = choice.getDelta().getContent();
+//                        if (delta != null && !delta.isBlank()) {
+//                            aiBuilder.append(delta);
+//                            consumer.accept(json);
+//                        }
+//
+//                        // 2) finish_reason 이 나오면 스트림 종료 플래그
+//                        if (choice.getFinishReason() != null) {
+//                            consumer.accept(json);
+//                            break;
+//                        }
+//                    }
+//
+//                } catch (Exception e) {
+//                    consumer.accept("[ERROR] " + e.getMessage());
+//                }
+//                Chatting aiChat = new Chatting();
+//                aiChat.setUid(userId);
+//                aiChat.setRole("assistant");
+//                aiChat.setContent(aiBuilder.toString());
+//                aiChat.setSessionId(sessionId);
+//                try {
+//                    chatbotDao.insertChatting(aiChat);
+//                } catch (Exception e) {
+//                    log.warn("AI 채팅 저장 실패: {}", e.getMessage());
+//                }
+//            }
             @Override
             public void onResponse(Call call, Response response) {
                 StringBuilder aiBuilder = new StringBuilder();
+                long cid = -1;
 
                 try (BufferedReader reader = new BufferedReader(
                         new InputStreamReader(response.body().byteStream()))) {
@@ -116,30 +161,43 @@ public class ChatbotService implements Chatbot{
                         String delta = choice.getDelta().getContent();
                         if (delta != null && !delta.isBlank()) {
                             aiBuilder.append(delta);
-                            consumer.accept(json);
+                            consumer.accept(json); // 중간 응답은 그대로
                         }
 
                         // 2) finish_reason 이 나오면 스트림 종료 플래그
                         if (choice.getFinishReason() != null) {
-                            consumer.accept(json);
-                            break;
+                            // DB 저장
+                            Chatting aiChat = new Chatting();
+                            aiChat.setUid(userId);
+                            aiChat.setRole("assistant");
+                            aiChat.setContent(aiBuilder.toString());
+                            aiChat.setSessionId(sessionId);
+                            try {
+                                chatbotDao.insertChatting(aiChat);
+                                cid = aiChat.getCid();
+                            } catch (Exception e) {
+                                log.warn("AI 채팅 저장 실패: {}", e.getMessage());
+                            }
+
+                            // 응답 JSON에 cid 추가
+                            try {
+                                Map<String, Object> parsed = mapper.readValue(json, Map.class);
+                                parsed.put("cid", cid);
+                                String newJson = mapper.writeValueAsString(parsed);
+                                consumer.accept(newJson);
+                            } catch (Exception e) {
+                                log.warn("cid 포함 응답 생성 실패", e);
+                                consumer.accept(json); // fallback
+                            }
+                            break; // 스트리밍 종료
                         }
                     }
 
                 } catch (Exception e) {
                     consumer.accept("[ERROR] " + e.getMessage());
                 }
-                Chatting aiChat = new Chatting();
-                aiChat.setUid(userId);
-                aiChat.setRole("assistant");
-                aiChat.setContent(aiBuilder.toString());
-                aiChat.setSessionId(sessionId);
-                try {
-                    chatbotDao.insertChatting(aiChat);
-                } catch (Exception e) {
-                    log.warn("AI 채팅 저장 실패: {}", e.getMessage());
-                }
             }
+
         });
     }
 


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
- OpenAI 채팅 스트리밍 응답(JSON)에 `cid`(채팅 ID)를 포함하도록 수정함

- AI 응답을 DB에 저장한 후 해당 cid를 마지막 스트림 응답에 포함시켜 프론트에서 TTS 요청 시 사용할 수 있게 개선

- Chatting 엔티티에 `cid` 필드 추가 및 MyBatis에서 `useGeneratedKeys`로 자동 매핑 처리

## 테스트
<!-- 테스트 방법 간략하게 작성 -->
1. 음성 입력을 통한 채팅 요청 후, 프론트 스트리밍 응답에서 cid 필드가 포함되는지 확인
2. `/chat/voice/tts/{cid}` 호출 시 해당 cid에 맞는 응답이 음성으로 정상 변환되는지 확인
<img width="425" alt="스크린샷 2025-06-23 오후 4 45 09" src="https://github.com/user-attachments/assets/98dd3641-a40e-44e9-b815-1191b7836efd" />


## 이슈
<!-- 관련 이슈 번호 (PR 병합 시 자동으로 이슈가 닫히도록 'closes #이슈번호' 형식 사용) -->
closes #
