### PR TITLE
Cham 89 새싹 키우기 히스토리 

### DIFF
--- a/src/main/java/com/example/demo/plant/controller/PlantController.java
+++ b/src/main/java/com/example/demo/plant/controller/PlantController.java
@@ -88,4 +88,18 @@ public class PlantController {
         Long uid = authService.getCurrentUserId();
         return ResponseEntity.ok(plantService.getRewardHistory(uid));
     }
+
+    @GetMapping("/rewards/family-history")
+    public ResponseEntity<List<RewardHistoryDto>> getFamilyRewardHistory() {
+        Long uid = authService.getCurrentUserId();
+        return ResponseEntity.ok(plantService.getRewardHistoryByFamily(uid));
+    }
+
+    @PatchMapping("/rewards/mark-used/{rewardLogId}")
+    @Operation(summary = "보상 사용 처리", description = "가족 보상 로그를 isUsed = true로 처리합니다.")
+    public ResponseEntity<Void> markRewardAsUsed(@PathVariable Long rewardLogId) {
+        Long uid = authService.getCurrentUserId();
+        plantService.markRewardAsUsed(uid, rewardLogId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/demo/plant/dao/PlantDao.java
+++ b/src/main/java/com/example/demo/plant/dao/PlantDao.java
@@ -36,4 +36,11 @@ public interface PlantDao {
     boolean hasAlreadyClaimedReward(@Param("uid") Long uid, @Param("pid") Long pid);
     // 보상 기록 확인 rewards
     RewardHistoryDto getRewardInfoById(@Param("rewardId") int rewardId);
+    //추가
+    //보상 수령 완료
+    void updateRewardLogUsed(@Param("rewardLogId") Long rewardLogId);
+    //우리 가족이 수령한 보상 전체
+    List<RewardHistoryDto> getRewardHistoryByFamily(@Param("fid") Long fid);
+    // 보상 로그 → 가족 ID 조회
+    Long getRewardFidByRewardLogId(@Param("rewardLogId") Long rewardLogId);
 }

--- a/src/main/java/com/example/demo/plant/dto/RewardHistoryDto.java
+++ b/src/main/java/com/example/demo/plant/dto/RewardHistoryDto.java
@@ -10,7 +10,10 @@ import lombok.Setter;
 @Getter
 @Setter
 public class RewardHistoryDto {
+    private Long rewardLogId;
+    private int rewardId;
     private String rewardName;
     private String description;
     private String receivedAt;
+    private boolean isUsed;
 }

--- a/src/main/java/com/example/demo/plant/service/PlantService.java
+++ b/src/main/java/com/example/demo/plant/service/PlantService.java
@@ -85,4 +85,18 @@ public class PlantService {
     public List<RewardHistoryDto> getRewardHistory(Long uid) {
         return plantDao.getRewardHistory(uid);
     }
+
+    public List<RewardHistoryDto> getRewardHistoryByFamily(Long uid) {
+        Long fid = plantDao.getUserFid(uid);   // 가족 ID로 변환
+        return plantDao.getRewardHistoryByFamily(fid); // 가족 전체 보상 조회
+    }
+
+    public void markRewardAsUsed(Long uid, Long rewardLogId) {
+        Long userFid = plantDao.getUserFid(uid);
+        Long rewardFid = plantDao.getRewardFidByRewardLogId(rewardLogId);
+
+        plantDao.updateRewardLogUsed(rewardLogId);
+    }
+
+
 }

--- a/src/main/java/com/example/demo/plant/service/PointService.java
+++ b/src/main/java/com/example/demo/plant/service/PointService.java
@@ -35,14 +35,14 @@ public class PointService {
 
     // 활동 유형별로 부여할 포인트 값을 매핑
     private final Map<String, Integer> activityPointMap = Map.of(
-            "attendance", 5,
-            "water", 5,
-            "nutrient", 10,
-            "emotion", 10,
-            "quiz", 10,
-            "lastleaf", 10,
-            "register", 10,
-            "survey", 5
+            "attendance", 200,
+            "water", 200,
+            "nutrient", 200,
+            "emotion", 100,
+            "quiz", 100,
+            "lastleaf", 100,
+            "register", 100,
+            "survey", 200
     );
 
     //활동에 따른 포인트 적립 및 경험치 처리

--- a/src/main/java/com/example/demo/plant/service/PointService.java
+++ b/src/main/java/com/example/demo/plant/service/PointService.java
@@ -35,14 +35,14 @@ public class PointService {
 
     // 활동 유형별로 부여할 포인트 값을 매핑
     private final Map<String, Integer> activityPointMap = Map.of(
-            "attendance", 200,
-            "water", 200,
-            "nutrient", 200,
-            "emotion", 100,
-            "quiz", 100,
-            "lastleaf", 100,
-            "register", 100,
-            "survey", 200
+            "attendance", 5,
+            "water", 5,
+            "nutrient", 10,
+            "emotion", 10,
+            "quiz", 10,
+            "lastleaf", 10,
+            "register", 10,
+            "survey", 5
     );
 
     //활동에 따른 포인트 적립 및 경험치 처리

--- a/src/main/resources/mapper/PlantMapper.xml
+++ b/src/main/resources/mapper/PlantMapper.xml
@@ -6,9 +6,12 @@
 
     <!-- ✅ RewardHistoryDto 매핑을 위한 resultMap -->
     <resultMap id="RewardMap" type="com.example.demo.plant.dto.RewardHistoryDto">
+        <result column="reward_log_id" property="rewardLogId"/> <!-- ✅ alias와 일치 -->
+        <result column="reward_id" property="rewardId"/>
         <result column="reward_name" property="rewardName"/>
         <result column="description" property="description"/>
         <result column="received_at" property="receivedAt"/>
+        <result column="isUsed" property="isUsed"/>
     </resultMap>
 
     <!-- 사용자 가족 ID 조회 -->
@@ -72,9 +75,15 @@
         VALUES (#{uid}, #{fid}, #{pid}, #{rewardId})
     </insert>
 
-    <!-- 사용자 보상 내역 조회 -->
+    <!-- 사용자 보상 내역 조회 //확인-->
     <select id="getRewardHistory" parameterType="long" resultMap="RewardMap">
-        SELECT r.reward_name, r.description, rl.received_at
+        SELECT
+        rl.rid AS reward_log_id,
+        rl.reward_id,
+        r.reward_name,
+        r.description,
+        rl.received_at,
+        rl.isUsed
         FROM reward_log rl
         JOIN rewards r ON rl.reward_id = r.reward_id
         WHERE rl.uid = #{uid}
@@ -96,6 +105,30 @@
         SELECT COUNT(*) > 0
         FROM reward_log
         WHERE uid = #{uid} AND pid = #{pid}
+    </select>
+    <!-- 보상을 수령해서 사용했는지 확인 -->
+    <update id="updateRewardLogUsed">
+        UPDATE reward_log
+        SET isUsed = 1
+        WHERE rid = #{rewardLogId}
+    </update>
+    <!-- 가족 전체의 보상 내역 확인 -->
+    <select id="getRewardHistoryByFamily" parameterType="long" resultMap="RewardMap">
+        SELECT
+        rl.rid AS reward_log_id,
+        rl.reward_id,
+        r.reward_name,
+        r.description,
+        rl.received_at,
+        rl.isUsed
+        FROM reward_log rl
+        JOIN rewards r ON rl.reward_id = r.reward_id
+        WHERE rl.fid = #{fid}
+        ORDER BY rl.received_at DESC
+    </select>
+    <!--  보상 로그 → 가족 fid 조회 -->
+    <select id="getRewardFidByRewardLogId" parameterType="long" resultType="long">
+        SELECT fid FROM reward_log WHERE rid = #{rewardLogId}
     </select>
 
 </mapper>


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
## 📌 주요 변경 사항

### 1. 가족 단위 보상 히스토리 조회 API 추가
- `GET /plants/rewards/family-history`
- 기존 `uid` 기반 보상 내역 → `fid` 기반으로 전체 가족 보상 내역 반환
- 반환 필드: 사용자 이름, 프로필 이미지, 보상명, 설명, 수령일, 사용 여부 포함

### 2. 보상 사용 완료 처리 API 추가
- `PATCH /plants/rewards/mark-used/{rewardLogId}`
- 보상 로그 ID 기반으로 `isUsed = true` 업데이트
- 가족 구성원 누구나 수령된 보상에 대해 사용 완료 처리 가능

### 3. RewardLog 관련 DAO 및 XML Mapper 수정
- family 기준 보상 로그 조회 쿼리 추가
- 보상 사용 처리 update 쿼리 추가
