### PR TITLE
CHAM-55 STT API sessionId 타입 불일치 해결

### DIFF
--- a/src/main/java/com/example/demo/voice/controller/VoiceController.java
+++ b/src/main/java/com/example/demo/voice/controller/VoiceController.java
@@ -45,7 +45,7 @@ public class VoiceController {
             )
             @RequestParam("audio_file") MultipartFile audioFile,
             @Parameter(description = "세션 ID")
-            @RequestParam("session_id") Long sessionId
+            @RequestParam("session_id") String sessionId
 //            @RequestHeader("Authorization") String authHeader
     ) throws IOException {
 //        String token = authHeader.replace("Bearer ", "");

--- a/src/main/java/com/example/demo/voice/service/VoiceService.java
+++ b/src/main/java/com/example/demo/voice/service/VoiceService.java
@@ -7,7 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface VoiceService {
     // 음성 업로드 처리 및 STT → 챗봇 응답 처리
-    TranscribedTextResponse handleAudioUpload(MultipartFile file, Long sessionId, String token);
+    TranscribedTextResponse handleAudioUpload(MultipartFile file, String sessionId, String token);
 
     // 텍스트 -> 음성 변환 + 저장
     TtsLogResponse convertAndLogTts(int cid, String text);

--- a/src/main/java/com/example/demo/voice/service/VoiceServiceImpl.java
+++ b/src/main/java/com/example/demo/voice/service/VoiceServiceImpl.java
@@ -34,7 +34,7 @@ public class VoiceServiceImpl implements VoiceService {
     음성 파일 업로드 및 STT 처리 -> 텍스트 추출 후 챗봇 응답 요청까지
      */
     @Override
-    public TranscribedTextResponse handleAudioUpload(MultipartFile file, Long sessionId, String token) {
+    public TranscribedTextResponse handleAudioUpload(MultipartFile file, String sessionId, String token) {
         try {
             // 1. 이메일 추출
 //            String email = jwtProvider.getEmail(token);


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
- **VoiceController**: STT API의 `session_id` 파라미터 타입을 `Long`에서 `String`으로 변경
- **VoiceService 인터페이스**: `handleAudioUpload` 메서드 시그니처 업데이트
- **VoiceServiceImpl**: 메서드 구현체 타입 변경


### 해결된 문제

- 프론트엔드(UUID 문자열)와 백엔드(Long 타입) 간 타입 불일치 문제 해결
- STT API 호출 시 403 Forbidden 에러 해결
- 실제 세션 ID를 사용한 정확한 음성 인식 처리
## 테스트
<!-- 테스트 방법 간략하게 작성 -->
1. **STT 기능 테스트**
   - 채팅 페이지에서 마이크 버튼 클릭
   - 명확한 음성으로 2-3초 이상 녹음
   - 음성이 텍스트로 정상 변환되는지 확인

2. **API 응답 확인**
   - 브라우저 개발자 도구에서 Network 탭 확인
   - `/chat/voice/upload` API 호출 시 UUID가 정상 전송되는지 확인
   - 응답에서 `transcribedText` 필드에 인식된 텍스트가 포함되는지 확인

3. **콘솔 로그 확인**
   - 오디오 Blob 크기 및 타입 정보 출력 확인
   - STT 응답 상세 정보 로깅 확인

## 이슈
<!-- 관련 이슈 번호 (PR 병합 시 자동으로 이슈가 닫히도록 'closes #이슈번호' 형식 사용) -->
closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the session ID parameter type from numeric to text format for audio upload and transcription features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->