### PR TITLE
CHAM-123 fix: 가족 메시지 타입 enums 수정

### DIFF
--- a/src/main/java/com/example/demo/familycard/controller/FamilyCardController.java
+++ b/src/main/java/com/example/demo/familycard/controller/FamilyCardController.java
@@ -1,6 +1,7 @@
 package com.example.demo.familycard.controller;
 
 import com.example.demo.familycard.dto.*;
+import com.example.demo.familycard.enums.MessageCardImageType;
 import com.example.demo.familycard.service.FamilyCardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -14,8 +15,10 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 가족 메시지 카드 관련 REST API 컨트롤러
@@ -271,11 +274,9 @@ public class FamilyCardController {
     })
     public ResponseEntity<List<Map<String, String>>> getImageTypes() {
         try {
-            List<Map<String, String>> imageTypes = List.of(
-                    Map.of("code", "heart", "description", "하트"),
-                    Map.of("code", "flower", "description", "꽃"),
-                    Map.of("code", "star", "description", "별")
-            );
+            List<Map<String, String>> imageTypes = Arrays.stream(MessageCardImageType.values())
+                    .map(type -> Map.of("code", type.getCode(), "description", type.getDescription()))
+                    .collect(Collectors.toList());
 
             return ResponseEntity.ok(imageTypes);
 

--- a/src/main/java/com/example/demo/familycard/dto/CreateFamilyCardRequest.java
+++ b/src/main/java/com/example/demo/familycard/dto/CreateFamilyCardRequest.java
@@ -16,7 +16,7 @@ public class CreateFamilyCardRequest {
 
     /**
      * 이미지 타입 코드
-     * 가능한 값: "heart", "flower", "star"
+     * 가능한 값: "heart", "flower", "sparkle", "leaf", "star"
      */
     @NotBlank(message = "이미지 타입은 필수입니다.")
     private String imageType;

--- a/src/main/java/com/example/demo/familycard/dto/UpdateFamilyCardRequest.java
+++ b/src/main/java/com/example/demo/familycard/dto/UpdateFamilyCardRequest.java
@@ -16,7 +16,7 @@ public class UpdateFamilyCardRequest {
 
     /**
      * 이미지 타입 코드
-     * 가능한 값: "heart", "flower", "star"
+     * 가능한 값: "heart", "flower", "sparkle", "leaf", "star"
      */
     @NotBlank(message = "이미지 타입은 필수입니다.")
     private String imageType;

--- a/src/main/java/com/example/demo/familycard/enums/MessageCardImageType.java
+++ b/src/main/java/com/example/demo/familycard/enums/MessageCardImageType.java
@@ -7,10 +7,9 @@ package com.example.demo.familycard.enums;
 public enum MessageCardImageType {
     HEART("heart", "하트"),
     FLOWER("flower", "꽃"),
-    STAR("star", "별"),
-    GIFT("gift", "선물"),
-    COFFEE("coffee", "커피"),
-    SUN("sun", "해");
+    SPARKLE("sparkle", "반짝"),
+    LEAF("leaf", "나뭇잎"),
+    STAR("star", "별");
 
 
     private final String code;


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
변경된 기능 사항에 따라 메시지 카드의 enums 타입 변경 및 관련 코드 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new image types "sparkle" and "leaf" to the available options for family cards.

* **Bug Fixes**
  * Image type list now updates dynamically to reflect current available options.

* **Documentation**
  * Updated documentation to include "sparkle" and "leaf" as valid image types for family cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->